### PR TITLE
Make MouseControllable::mouse_location() also work on Windows

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,12 +2,12 @@ use libc;
 
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
-use self::libc::{c_char, c_int, c_void, useconds_t};
+use self::libc::{c_char, c_int, c_ulong, c_void, useconds_t};
 use std::{borrow::Cow, ffi::CString, ptr};
 
-const CURRENT_WINDOW: c_int = 0;
+const CURRENT_WINDOW: Window = 0;
 const DEFAULT_DELAY: u64 = 12000;
-type Window = c_int;
+type Window = c_ulong;
 type Xdo = *const c_void;
 
 #[link(name = "xdo")]
@@ -26,7 +26,7 @@ extern "C" {
         x: &c_int,
         y: &c_int,
         screen: &c_int,
-        window: &c_int
+        window: &Window
     ) -> c_int;
     fn xdo_enter_text_window(
         xdo: Xdo,
@@ -109,14 +109,14 @@ impl MouseControllable for Enigo {
         let mut x: i32 = 0;
         let mut y: i32 = 0;
         let mut screen: i32 = 0;
-        let mut window: i32 = 0;
+        let mut window: u64 = 0;
         unsafe {
             xdo_get_mouse_location2(
                 self.xdo,
                 &x as &c_int,
                 &y as &c_int,
                 &screen as &c_int,
-                &window as &c_int);
+                &window as &Window);
         }
         return (x, y)
     }

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -46,6 +46,10 @@ fn keybd_event(flags: u32, vk: u16, scan: u16) {
 }
 
 impl MouseControllable for Enigo {
+    fn mouse_location(&mut self) -> (i32, i32) {
+        Enigo::mouse_location()
+    }
+    
     fn mouse_move_to(&mut self, x: i32, y: i32) {
         mouse_event(
             MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK,

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -101,7 +101,7 @@ impl MouseControllable for Enigo {
     }
 
     fn mouse_scroll_y(&mut self, length: i32) {
-        mouse_event(MOUSEEVENTF_WHEEL, unsafe { transmute(length * 120) }, 0, 0);
+        mouse_event(MOUSEEVENTF_WHEEL, unsafe { transmute(length * -120) }, 0, 0);
     }
 }
 


### PR DESCRIPTION
First of all, thanks for the work to make mouse_location() available on Linux! This was useful to me, but unfortunately, it broke the Windows build of enigo, because the Windows impl didn't include the new trait method (and I'm writing something that's intended to run on both Linux and Windows). So here's a quick fix.

Note: this leaves Enigo::mouse_location() in place, meaning there are 2 different ways to get the mouse location if you know you are on Windows. It's not obvious to me whether this is good or bad – I'm just making the minimal change to make the same code work on both Linux/X11 and Windows.